### PR TITLE
Fixes Uploader Dropzone

### DIFF
--- a/app/uploader/templates/upload.html
+++ b/app/uploader/templates/upload.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block header %}
+{% block head %}
     {{ super() }}
     {{ dropzone.load_css() }}
     {{ dropzone.style('border: 10px dashed gray; margin: auto; min-height: 200px; max-width: 500px') }}


### PR DESCRIPTION
This PR builds upon PR #8 and fixes the Uploader dropzone area. The cause was a combination of the CSS not working properly (fixed in PR #8) and incorrect inheritance in `upload.html`.

Now looks like this:

![image](https://user-images.githubusercontent.com/15610752/173384536-959d1f40-a7bf-4957-ba2a-82994dd11410.png)

Note, the upload works, but the user experience is still lacking. Now, when the user drags a DICOM into the Dropzone, it is automatically uploaded. There is no prompt to ask if the user is sure about this, etc. Also, the Upload button seemingly doesn't do anything at all. 

Resolves #6