### PR TITLE
Fixes results table in report.html

### DIFF
--- a/app/reports/templates/report.html
+++ b/app/reports/templates/report.html
@@ -2,7 +2,6 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 
 {% block app_content %}
-
     {% if pending %}
         <table class="table table-striped"></table>
     {% endif %}
@@ -17,28 +16,32 @@
     {% else %}
         {% for fact in facts %}
             <table class="table table-striped">
+
                 <caption>
                     Status: {{ fact.status }}<br>
                     Task: {{ fact.task.name }}<br>
                     Variables: {{ fact.process_task_variables }}<br>
                     Created: {{ moment(fact.created_at.naive).fromNow() }}<br>
                 </caption>
+
                 <thead>
-                <tr>
-                    <th>Measurement</th>
-                    <th>Value</th>
-                </tr>
+                    <tr>
+                        <th>Measurement</th>
+                        <th>Value</th>
+                    </tr>
                 </thead>
+
                 <tbody>
-                <tr>
-                {% for key, value in fact.data.items() %}
-                    {% for key, value in value.items() %}
-                        <td>{{ key }}</td>
-                        <td>{{ value }}</td>
+                    {% for key, value in fact.data.items() %}
+                        {% for key, value in value.items() %}
+                            <tr>
+                                <td>{{ key }}</td>
+                                <td>{{ value }}</td>
+                            </tr>
+                        {% endfor %}
                     {% endfor %}
-                {% endfor %}
-                </tr>
                 </tbody>
+
             </table>
 
         {% endfor %}


### PR DESCRIPTION
Small PR to fix the Report results table. Now, each result is on a separate row of the table, whereas previously all results were in a single row and therefore meant the user had to scroll rightwards.

Looks like this now:

![image](https://user-images.githubusercontent.com/15610752/173407113-276b672e-84bd-4d80-917e-81474b116403.png)

NB: still need to fix the Process Task code to work with hazenlib – figured out how to do this, but not implemented properly yet.