### PR TITLE
fix task interaction by loading images into DICOM dataset

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,4 +1,7 @@
+"""Tasks module, specifying Hazen-related tasks and utilities."""
+
 import os
+import pydicom
 
 from flask import current_app, flash, jsonify
 
@@ -8,30 +11,38 @@ from hazen import worker
 
 
 @worker.task(bind=True)
-def produce_report(self, fn, acquisition):
-    task = __import__(f'hazenlib.{fn}', globals(), locals(), [f'{fn}'])
+def produce_report(self, function_name, acquisition):
+    # import Hazen functionality
+    task = __import__(f'hazenlib.{function_name}', globals(), locals(), [f'{function_name}'])
     current_app.logger.info(f"Producing report from {task.__name__}")
-    process = ProcessTask.query.filter_by(name=fn).first()
+    process = ProcessTask.query.filter_by(name=function_name).first()
+
+    # Select files to perform task on
     filesystem_folder = os.path.join(current_app.config['UPLOADED_PATH'],
-                                     acquisition['author_hex'],
-                                     acquisition['hex'])
+                                    acquisition['author_hex'],
+                                    acquisition['hex'])
+    image_files = [os.path.join(filesystem_folder, file) for file in os.listdir(filesystem_folder)]
+    # Load images into DICOM dataset
+    dcms = [pydicom.read_file(x, force=True) for x in image_files]
 
-    dcms = [os.path.join(filesystem_folder, f) for f in os.listdir(filesystem_folder)]
-
+    # Ensure that appropriate number of files were selected
     if len(dcms) != acquisition['files']:
         raise Exception('Number of dicoms in directory not equal to expected!')
 
+    # Perform analysis/task
     self.update_state(state='IN PROGRESS')
     self.acquisition_id = acquisition['hex']
-    res = task.main(data=dcms)
+    # Perform task and generate result
+    result = task.main(data=dcms)
     self.update_state(state='STORING RESULTS')
+    # Store analysis result in database
     fact = Fact(user_id=acquisition['author_id'],
                 acquisition_id=acquisition['id'],
                 process_task=process.id,
                 process_task_variables={},
-                data=res,
+                data=result,
                 status='Complete')
-
+    # Save information to database
     fact.save()
-    flash(f'Completed process: {fn}')
+    flash(f'Completed process: {function_name}')
     return jsonify(fact.data)


### PR DESCRIPTION
partially solves #19 
slice_width, uniformity and spatial_resolution now work, although page has to be manually reloaded to show results.
Current page by default shows the acquisition hex ID and the result_id of the celery job
![image](https://user-images.githubusercontent.com/15593138/179365667-ef9710fb-0695-4166-95d2-f823fd5b2cb1.png)
Only after refreshing the page it shows the resulting values:
![image](https://user-images.githubusercontent.com/15593138/179365700-60abebb3-a16b-4e49-b087-c19771bdfb78.png)
Additional changes are required to the reports.html to display the task results immediately.

Furthermore, other tasks do not conform with either input or output requirements. It is expected that task scripts in hazenlib have an input variable called `data` that takes a list of DICOM loaded images. Relaxometry expects an input variable called `dcm_target_list` instead. It is expected that the output, `result` variable is a nested dictionary in the format of `{image_description: {measurement1: value1, measurement2: value2}}`, however SNR and ghosting output a flat dictionary with a single value, like `{image_description: value}`. Task input variables and output format needs to be standardised in hazenlib.