### PR TITLE
fix upload function

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -80,7 +80,6 @@ def workbench():
     form = ImageUploadForm()
 
     if request.method == 'POST' and form.is_submitted():
-        print("post request")
         # Uploaded by DropZone
         for dropzone_file in request.files.getlist('file'):
             upload_file(dropzone_file)


### PR DESCRIPTION
previously uploading via Choose File form option only the first file was uploaded even if multiple were selected.
It is now fixed by separating the file upload function from the workbench route, and also retrieving the list of selected files from the request in a more robust way (`request.files.getlist()` rather than `request.files.items()`)