### PR TITLE
Display study description in series overview

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -256,6 +256,9 @@ def series_view(series_id):
     user_id = current_user.id
     # Retrieve the Series that was selected
     series = Series.query.filter_by(id=series_id).first_or_404()
+    study_id = series.study_id
+    study = Study.query.filter_by(id=study_id).one_or_none()
+
 
     if request.method == "GET":
         # Prepare the form to accept task selection
@@ -271,6 +274,7 @@ def series_view(series_id):
             "created_at": series.created_at,
             "series_files": Image.query.filter_by(series_id=series_id).count(),
             "has_report": series.has_report,
+            "study_description": study.description
         }
 
         # Identify reports made for that series_id

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -257,10 +257,6 @@ def series_view(series_id):
     # Retrieve the Series that was selected
     series = Series.query.filter_by(id=series_id).first_or_404()
     study_id = series.study_id
-    study = Study.query.filter_by(id=study_id).one_or_none()
-
-
-
     device_id=series.device_id
     study = Study.query.filter_by(id=study_id).one_or_none()
     device = Device.query.filter_by(id=device_id).first()
@@ -280,7 +276,9 @@ def series_view(series_id):
             "series_files": Image.query.filter_by(series_id=series_id).count(),
             "has_report": series.has_report,
             "study_description": study.description,
-            "manufacturer": device.manufacturer
+            "manufacturer": device.manufacturer,
+            "device_name": device.device_model
+
 
         }
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -257,8 +257,15 @@ def series_view(series_id):
     # Retrieve the Series that was selected
     series = Series.query.filter_by(id=series_id).first_or_404()
     study_id = series.study_id
+<<<<<<< Updated upstream
     study = Study.query.filter_by(id=study_id).one_or_none()
 
+
+=======
+
+    device_id=series.device_id
+    study = Study.query.filter_by(id=study_id).one_or_none()
+    device = Device.query.filter_by(id=device_id).first()
 
     if request.method == "GET":
         # Prepare the form to accept task selection
@@ -274,7 +281,11 @@ def series_view(series_id):
             "created_at": series.created_at,
             "series_files": Image.query.filter_by(series_id=series_id).count(),
             "has_report": series.has_report,
+<<<<<<< Updated upstream
             "study_description": study.description
+            "study_description": study.description,
+            "manufacturer": device.manufacturer
+
         }
 
         # Identify reports made for that series_id

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -257,11 +257,9 @@ def series_view(series_id):
     # Retrieve the Series that was selected
     series = Series.query.filter_by(id=series_id).first_or_404()
     study_id = series.study_id
-<<<<<<< Updated upstream
     study = Study.query.filter_by(id=study_id).one_or_none()
 
 
-=======
 
     device_id=series.device_id
     study = Study.query.filter_by(id=study_id).one_or_none()
@@ -281,8 +279,6 @@ def series_view(series_id):
             "created_at": series.created_at,
             "series_files": Image.query.filter_by(series_id=series_id).count(),
             "has_report": series.has_report,
-<<<<<<< Updated upstream
-            "study_description": study.description
             "study_description": study.description,
             "manufacturer": device.manufacturer
 

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -47,6 +47,10 @@
                     <th>Reports made</th>
                     <td>{{ series.has_report }}</td>
                 </tr>
+                <tr>
+                    <th>Study Description</th>
+                    <td>{{ series.study_description }}</td>
+                </tr>
             </table>
         </div>
     </div>

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -56,7 +56,7 @@
                     <td>{{ series.created_at.format('YYYY-MM-DD HH:mm') }}</td>
                 </tr>
                 <tr>
-                    <th>Has Reports</th>
+                    <th>Has Results</th>
                     <td>{{ series.has_report }}</td>
                 </tr>
             </table>

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -28,12 +28,20 @@
             <h4 class="h4 text-center">Series description</h4></br>
             <table class="table table-striped"> <!-- Series information -->
                 <tr>
-                    <th>Series description</th>
-                    <td>{{ series.description }}</td>
+                    <th>Acquisition date</th>
+                    <td>{{ series.series_datetime.strftime('%Y-%m-%d') }}</td>
                 </tr>
                 <tr>
-                    <th>Acquisition date</th>
-                    <td>{{ series.series_datetime }}</td>
+                     <th>Study Description</th>
+                     <td>{{ series.study_description }}</td>
+                 </tr>
+                <tr>
+                    <th>Manufacturer</th>
+                    <td>{{ series.manufacturer }}</td>
+                </tr>
+                <tr>
+                    <th>Series description</th>
+                    <td>{{ series.description }}</td>
                 </tr>
                 <tr>
                     <th>Uploaded date</th>

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -53,7 +53,7 @@
                 </tr>
                 <tr>
                     <th>Uploaded Date</th>
-                    <td>{{ series.created_at.format('YYYY-MM-DD HH:mm') }}</td>
+                    <td>{{ series.created_at.format('YYYY-MM-DD') }}</td>
                 </tr>
                 <tr>
                     <th>Has Results</th>

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -48,12 +48,12 @@
                     <td>{{ series.description }}</td>
                 </tr>
                 <tr>
-                    <th>Uploaded date</th>
-                    <td>{{ series.created_at.format('YYYY-MM-DD HH:mm') }}</td>
-                </tr>
-                <tr>
                     <th>Files in series</th>
                     <td>{{ series.series_files }}</td>
+                </tr>
+                <tr>
+                    <th>Uploaded date</th>
+                    <td>{{ series.created_at.format('YYYY-MM-DD HH:mm') }}</td>
                 </tr>
                 <tr>
                     <th>Reports made</th>

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -40,6 +40,10 @@
                     <td>{{ series.manufacturer }}</td>
                 </tr>
                 <tr>
+                    <th>Device Name</th>
+                    <td>{{ series.device_name }}</td>
+                </tr>
+                <tr>
                     <th>Series description</th>
                     <td>{{ series.description }}</td>
                 </tr>

--- a/app/main/templates/series_view.html
+++ b/app/main/templates/series_view.html
@@ -28,7 +28,7 @@
             <h4 class="h4 text-center">Series description</h4></br>
             <table class="table table-striped"> <!-- Series information -->
                 <tr>
-                    <th>Acquisition date</th>
+                    <th>Acquisition Date</th>
                     <td>{{ series.series_datetime.strftime('%Y-%m-%d') }}</td>
                 </tr>
                 <tr>
@@ -44,24 +44,20 @@
                     <td>{{ series.device_name }}</td>
                 </tr>
                 <tr>
-                    <th>Series description</th>
+                    <th>Series Description</th>
                     <td>{{ series.description }}</td>
                 </tr>
                 <tr>
-                    <th>Files in series</th>
+                    <th>Files in Series</th>
                     <td>{{ series.series_files }}</td>
                 </tr>
                 <tr>
-                    <th>Uploaded date</th>
+                    <th>Uploaded Date</th>
                     <td>{{ series.created_at.format('YYYY-MM-DD HH:mm') }}</td>
                 </tr>
                 <tr>
-                    <th>Reports made</th>
+                    <th>Has Reports</th>
                     <td>{{ series.has_report }}</td>
-                </tr>
-                <tr>
-                    <th>Study Description</th>
-                    <td>{{ series.study_description }}</td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
The study description from DICOM headers (0008,1030) is now displayed in the table on the series overview page.



![Screenshot 2024-02-08 at 14 15 37](https://github.com/GSTT-CSC/hazen-web-app/assets/141416713/7fa9e3ca-6d96-4832-9ca2-0df174242757)
